### PR TITLE
Fix className prop in Artifact.tsx

### DIFF
--- a/app/components/chat/Artifact.tsx
+++ b/app/components/chat/Artifact.tsx
@@ -102,14 +102,14 @@ export const Artifact = memo(({ messageId }: ArtifactProps) => {
 });
 
 interface ShellCodeBlockProps {
-  classsName?: string;
+  className?: string;
   code: string;
 }
 
-function ShellCodeBlock({ classsName, code }: ShellCodeBlockProps) {
+function ShellCodeBlock({ className, code }: ShellCodeBlockProps) {
   return (
     <div
-      className={classNames('text-xs', classsName)}
+      className={classNames('text-xs', className)}
       dangerouslySetInnerHTML={{
         __html: shellHighlighter.codeToHtml(code, {
           lang: 'shell',
@@ -175,7 +175,7 @@ const ActionList = memo(({ actions }: ActionListProps) => {
               </div>
               {type === 'shell' && (
                 <ShellCodeBlock
-                  classsName={classNames('mt-1', {
+                  className={classNames('mt-1', {
                     'mb-3.5': !isLast,
                   })}
                   code={content}


### PR DESCRIPTION
## Summary
- rename `classsName` prop to `className`
- update all usage of the prop within `Artifact.tsx`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find ESLint plugin)*
- `npm run typecheck` *(fails: missing type definition packages)*