### PR TITLE
Fix resize observer cleanup

### DIFF
--- a/app/lib/hooks/useSnapScroll.ts
+++ b/app/lib/hooks/useSnapScroll.ts
@@ -19,6 +19,8 @@ export function useSnapScroll() {
         }
       });
 
+      observerRef.current = observer;
+
       observer.observe(node);
     } else {
       observerRef.current?.disconnect();


### PR DESCRIPTION
## Summary
- store created `ResizeObserver` in a ref
- clean up via the ref when the node unmounts

## Testing
- `pnpm test` *(fails: could not download dependencies)*