### PR TITLE
Add OpenAI provider support

### DIFF
--- a/app/lib/.server/llm/api-key.ts
+++ b/app/lib/.server/llm/api-key.ts
@@ -1,9 +1,14 @@
 import { env } from 'node:process';
 
-export function getAPIKey(cloudflareEnv: Env) {
+export function getAPIKey(
+  cloudflareEnv: Env,
+  provider: 'anthropic' | 'openai' = 'anthropic',
+) {
   /**
    * The `cloudflareEnv` is only used when deployed or when previewing locally.
    * In development the environment variables are available through `env`.
    */
-  return env.ANTHROPIC_API_KEY || cloudflareEnv.ANTHROPIC_API_KEY;
+  const varName = provider === 'openai' ? 'OPENAI_API_KEY' : 'ANTHROPIC_API_KEY';
+  return (env as Record<string, string | undefined>)[varName] ||
+    (cloudflareEnv as Record<string, string | undefined>)[varName];
 }

--- a/app/lib/.server/llm/stream-text.ts
+++ b/app/lib/.server/llm/stream-text.ts
@@ -3,6 +3,7 @@ import { getAPIKey } from '~/lib/.server/llm/api-key';
 import { getAnthropicModel } from '~/lib/.server/llm/model';
 import { MAX_TOKENS } from './constants';
 import { getSystemPrompt } from './prompts';
+import { request } from '~/lib/fetch';
 
 interface ToolResult<Name extends string, Args, Result> {
   toolCallId: string;
@@ -19,17 +20,81 @@ interface Message {
 
 export type Messages = Message[];
 
-export type StreamingOptions = Omit<Parameters<typeof _streamText>[0], 'model'>;
+export type StreamingOptions =
+  Omit<Parameters<typeof _streamText>[0], 'model'> & {
+    provider?: 'anthropic' | 'openai';
+  };
 
-export function streamText(messages: Messages, env: Env, options?: StreamingOptions) {
-  return _streamText({
-    model: getAnthropicModel(getAPIKey(env)),
+interface StreamTextResult {
+  toAIStream(): ReadableStream;
+}
+export async function streamText(
+  messages: Messages,
+  env: Env,
+  options: StreamingOptions = {},
+): Promise<StreamTextResult> {
+  const provider = options.provider || env.LLM_PROVIDER || 'anthropic';
+
+  if (provider === 'openai') {
+    return streamOpenAIText(messages, env, options);
+  }
+
+  const { provider: _p, ...otherOptions } = options;
+
+  const result = await _streamText({
+    model: getAnthropicModel(getAPIKey(env, 'anthropic')),
     system: getSystemPrompt(),
     maxTokens: MAX_TOKENS,
     headers: {
       'anthropic-beta': 'max-tokens-3-5-sonnet-2024-07-15',
     },
     messages: convertToCoreMessages(messages),
-    ...options,
+    ...otherOptions,
   });
+
+  return {
+    toAIStream() {
+      return result.toAIStream();
+    },
+  };
+}
+
+async function streamOpenAIText(
+  messages: Messages,
+  env: Env,
+  options: StreamingOptions,
+): Promise<StreamTextResult> {
+  const apiKey = getAPIKey(env, 'openai');
+
+  const res = await request('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: 'gpt-4o',
+      messages: messages.map(({ role, content }) => ({ role, content })),
+      max_tokens: MAX_TOKENS,
+      stream: false,
+    }),
+  });
+
+  const data = await res.json();
+
+  const text: string = data.choices?.[0]?.message?.content ?? '';
+  options.onFinish?.({ text, finishReason: data.choices?.[0]?.finish_reason });
+
+  const encoder = new TextEncoder();
+
+  return {
+    toAIStream() {
+      return new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode(text));
+          controller.close();
+        },
+      });
+    },
+  };
 }

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -1,3 +1,8 @@
 interface Env {
-  ANTHROPIC_API_KEY: string;
+  ANTHROPIC_API_KEY?: string;
+  OPENAI_API_KEY?: string;
+  GOOGLE_API_KEY?: string;
+  OFFICE365_API_KEY?: string;
+  MAKE_API_KEY?: string;
+  LLM_PROVIDER?: 'anthropic' | 'openai';
 }


### PR DESCRIPTION
## Summary
- extend Env configuration to support multiple providers
- choose model provider in streamText()
- add simplified OpenAI integration via fetch

## Testing
- `npm run typecheck` *(fails: cannot find packages)*
- `npm run lint` *(fails: missing eslint plugin)*
- `npm test` *(fails: vitest not found)*